### PR TITLE
Create multiselect menu with items preselected

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ you can define another set of keys to toggle a selected item. By passing `show_m
 mode hint is shown in the status bar. If you don't want the `accept_key` to also select the last highlighted item you
 can pass `multi_select_select_on_accept=False` (if no menu item is explicitly selected, the last highlighted menu item
 will still be added to the selection).
+An optional list 'preselected_entries' can also be passed to have items already selected when the menu is displayed.
+This list can be composed of either integers representing indexes of the menu_entries list, or strings matching the
+elements of menu_entries. Mixing types is not allowed.
 
 #### Multi-select example
 

--- a/README.md
+++ b/README.md
@@ -231,9 +231,10 @@ you can define another set of keys to toggle a selected item. By passing `show_m
 mode hint is shown in the status bar. If you don't want the `accept_key` to also select the last highlighted item you
 can pass `multi_select_select_on_accept=False` (if no menu item is explicitly selected, the last highlighted menu item
 will still be added to the selection).
-An optional list 'preselected_entries' can also be passed to have items already selected when the menu is displayed.
-This list can be composed of either integers representing indexes of the menu_entries list, or strings matching the
-elements of menu_entries. Mixing types is not allowed.
+
+An optional list (or any other iterable object) `preselected_entries` can also be passed to have items already selected
+when the menu is displayed.  This list can be composed of either integers representing indexes of the `menu_entries`
+list, or strings matching the elements of `menu_entries`. Integers and strings can be mixed.
 
 #### Multi-select example
 
@@ -435,6 +436,7 @@ usage: simple-term-menu [-h] [-s] [-X] [-l] [--cursor CURSOR]
                         [--show-shortcut-hints-in-title] [-b STATUS_BAR] [-d]
                         [--status-bar-style STATUS_BAR_STYLE] [--stdout]
                         [-t TITLE] [-V]
+                        [-r PRESELECTED_ENTRIES | -R PRESELECTED_INDICES]
                         [entries ...]
 
 simple-term-menu creates simple interactive menus in the terminal and returns the selected entry as exit code.
@@ -528,6 +530,12 @@ optional arguments:
   -t TITLE, --title TITLE
                         menu title
   -V, --version         print the version number and exit
+  -r PRESELECTED_ENTRIES, --preselected_entries PRESELECTED_ENTRIES
+                        Comma separated list of strings matching menu items to
+                        start pre-selected in a multi-select menu.
+  -R PRESELECTED_INDICES, --preselected_indices PRESELECTED_INDICES
+                        Comma separated list of numeric indexes of menu items
+                        to start pre-selected in a multi-select menu.
 ```
 
 #### Example with preview option

--- a/simple_term_menu.py
+++ b/simple_term_menu.py
@@ -268,6 +268,7 @@ class TerminalMenu:
             selection: "TerminalMenu.Selection",
             viewport: "TerminalMenu.Viewport",
             cycle_cursor: bool = True,
+            preselected_entries: Iterable[str] = None,
         ):
             self._menu_entries = list(menu_entries)
             self._search = search
@@ -275,6 +276,9 @@ class TerminalMenu:
             self._viewport = viewport
             self._cycle_cursor = cycle_cursor
             self._active_displayed_index = None  # type: Optional[int]
+            if preselected_entries is not None:
+                for idx in list(map(menu_entries.index, preselected_entries)):
+                    self._selection.add(idx)
             self.update_view()
 
         def update_view(self) -> None:
@@ -534,6 +538,7 @@ class TerminalMenu:
         multi_select_cursor_style: Optional[Iterable[str]] = DEFAULT_MULTI_SELECT_CURSOR_STYLE,
         multi_select_keys: Optional[Iterable[str]] = DEFAULT_MULTI_SELECT_KEYS,
         multi_select_select_on_accept: bool = DEFAULT_MULTI_SELECT_SELECT_ON_ACCEPT,
+        preselected_entries: Iterable[str] = None,
         preview_border: bool = DEFAULT_PREVIEW_BORDER,
         preview_command: Optional[Union[str, Callable[[str], str]]] = None,
         preview_size: float = DEFAULT_PREVIEW_SIZE,
@@ -620,6 +625,7 @@ class TerminalMenu:
         )
         self._multi_select_keys = tuple(multi_select_keys) if multi_select_keys is not None else ()
         self._multi_select_select_on_accept = multi_select_select_on_accept
+        self._preselected_entries = preselected_entries
         self._preview_border = preview_border
         self._preview_command = preview_command
         self._preview_size = preview_size
@@ -679,7 +685,7 @@ class TerminalMenu:
             0,
             0,
         )
-        self._view = self.View(self._menu_entries, self._search, self._selection, self._viewport, self._cycle_cursor)
+        self._view = self.View(self._menu_entries, self._search, self._selection, self._viewport, self._cycle_cursor, self._preselected_entries)
         if cursor_index and 0 < cursor_index < len(self._menu_entries):
             self._view.active_menu_index = cursor_index
         self._search.change_callback = self._view.update_view
@@ -1357,7 +1363,8 @@ class TerminalMenu:
         # pylint: disable=unsubscriptable-object
         assert self._codename_to_terminal_code is not None
         self._init_term()
-        self._selection.clear()
+        if self._preselected_entries is None:
+            self._selection.clear()
         self._chosen_accept_key = None
         self._chosen_menu_indices = None
         self._chosen_menu_index = None

--- a/simple_term_menu.py
+++ b/simple_term_menu.py
@@ -89,8 +89,10 @@ class NoMenuEntriesError(Exception):
 class PreviewCommandFailedError(Exception):
     pass
 
+
 class MixedTypesError(Exception):
     pass
+
 
 def get_locale() -> str:
     user_locale = locale.getlocale()[1]
@@ -536,7 +538,7 @@ class TerminalMenu:
         multi_select_cursor_style: Optional[Iterable[str]] = DEFAULT_MULTI_SELECT_CURSOR_STYLE,
         multi_select_keys: Optional[Iterable[str]] = DEFAULT_MULTI_SELECT_KEYS,
         multi_select_select_on_accept: bool = DEFAULT_MULTI_SELECT_SELECT_ON_ACCEPT,
-        preselected_entries: Sequence[Union[str, int]] = None,
+        preselected_entries: Optional[Sequence[Union[str, int]]] = None,
         preview_border: bool = DEFAULT_PREVIEW_BORDER,
         preview_command: Optional[Union[str, Callable[[str], str]]] = None,
         preview_size: float = DEFAULT_PREVIEW_SIZE,
@@ -691,10 +693,14 @@ class TerminalMenu:
                 for item in self._preselected_entries:
                     if type(item) is not int:
                         raise MixedTypesError("Error: Cannot mix string and integer types in preselected_entries.")
-                    if (item >= 0) and (item <= (len(self._menu_entries) -1)):
+                    if (item >= 0) and (item <= (len(self._menu_entries) - 1)):
                         self._selection[item] = True
                     else:
-                        raise IndexError("Error: {} is outside the allowable range of 0..{}.".format(item,len(self._menu_entries)-1))
+                        raise IndexError(
+                            "Error: {} is outside the allowable range of 0..{}.".format(
+                                item, len(self._menu_entries) - 1
+                            )
+                        )
         self._viewport = self.Viewport(
             len(self._menu_entries),
             len(self._title_lines),
@@ -1759,14 +1765,14 @@ def get_argumentparser() -> argparse.ArgumentParser:
         "--preselected_entries",
         action="store",
         dest="preselected_entries",
-        help="Comma separated list of strings matching menu items to start pre-selected in a multi-select menu."
+        help="Comma separated list of strings matching menu items to start pre-selected in a multi-select menu.",
     )
     group.add_argument(
         "-R",
         "--preselected_indices",
         action="store",
         dest="preselected_indices",
-        help="Comma separated list of ints representing indexes of menu items to start pre-selected in a multi-select menu."
+        help="Comma separated list of numeric indexes of menu items to start pre-selected in a multi-select menu.",
     )
     return parser
 
@@ -1821,7 +1827,7 @@ def parse_arguments() -> AttributeDict:
     if args.preselected_entries is not None:
         args.preselected = list(args.preselected_entries.split(","))
     elif args.preselected_indices is not None:
-        args.preselected = list(map(int,args.preselected_indices.split(",")))
+        args.preselected = list(map(int, args.preselected_indices.split(",")))
     else:
         args.preselected = None
     return args


### PR DESCRIPTION
Added parameter preselected_entries, a list of menu_entries items to be pre-checked in a multiselect menu.

I didn't add a corresponding entry to the argument parse, I wasn't sure if that was {des|requ}ired but I can go back and add it if necessary.