### PR TITLE
Allow multiselect menu to return with no selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ multi-select mode, the `show` method returns a sorted tuple of all your selected
 Use the `chosen_menu_entries` property to get a tuple of the menu entry strings instead. By setting `multi_select_keys`
 you can define another set of keys to toggle a selected item. By passing `show_multi_select_hint=True` a multi-select
 mode hint is shown in the status bar. If you don't want the `accept_key` to also select the last highlighted item you
-can pass `multi_select_select_on_accept=False` (if no menu item is explicitly selected, the last highlighted menu item
-will still be added to the selection).
+can pass `multi_select_select_on_accept=False`. If no menu item is explicitly selected, the last highlighted menu item
+will still be added to the selection unless you also pass `multi_select_empty_ok=True`.
 
 An optional list (or any other iterable object) `preselected_entries` can also be passed to have items already selected
 when the menu is displayed.  This list can be composed of either integers representing indexes of the `menu_entries`

--- a/simple_term_menu.py
+++ b/simple_term_menu.py
@@ -540,6 +540,7 @@ class TerminalMenu:
         multi_select_cursor: str = DEFAULT_MULTI_SELECT_CURSOR,
         multi_select_cursor_brackets_style: Optional[Iterable[str]] = DEFAULT_MULTI_SELECT_CURSOR_BRACKETS_STYLE,
         multi_select_cursor_style: Optional[Iterable[str]] = DEFAULT_MULTI_SELECT_CURSOR_STYLE,
+        multi_select_empty_ok: bool = False,
         multi_select_keys: Optional[Iterable[str]] = DEFAULT_MULTI_SELECT_KEYS,
         multi_select_select_on_accept: bool = DEFAULT_MULTI_SELECT_SELECT_ON_ACCEPT,
         preselected_entries: Optional[Iterable[Union[str, int]]] = None,
@@ -642,6 +643,7 @@ class TerminalMenu:
         self._clear_menu_on_exit = clear_menu_on_exit
         self._clear_screen = clear_screen
         self._cycle_cursor = cycle_cursor
+        self._multi_select_empty_ok = multi_select_empty_ok
         self._exit_on_shortcut = exit_on_shortcut
         self._menu_cursor = menu_cursor if menu_cursor is not None else ""
         self._menu_cursor_style = tuple(menu_cursor_style) if menu_cursor_style is not None else ()
@@ -1448,7 +1450,9 @@ class TerminalMenu:
                         self._selection.toggle(self._view.active_menu_index)
                 elif next_key in current_menu_action_to_keys["accept"]:
                     if self._view.active_menu_index is not None:
-                        if self._multi_select_select_on_accept or not self._selection:
+                        if self._multi_select_select_on_accept or (
+                            not self._selection and self._multi_select_empty_ok is False
+                        ):
                             self._selection.add(self._view.active_menu_index)
                     self._chosen_accept_key = next_key
                     break
@@ -1631,6 +1635,12 @@ def get_argumentparser() -> argparse.ArgumentParser:
             "do not select the currently highlighted menu item when the accept key is pressed "
             "(it is still selected if no other item was selected before)"
         ),
+    )
+    parser.add_argument(
+        "--multi-select-empty-ok",
+        action="store_true",
+        dest="multi_select_empty_ok",
+        help=("when used together with --multi-select-no-select-on-accept allows returning no selection at all"),
     )
     parser.add_argument(
         "-p",
@@ -1873,6 +1883,7 @@ def main() -> None:
             multi_select_cursor=args.multi_select_cursor,
             multi_select_cursor_brackets_style=args.multi_select_cursor_brackets_style,
             multi_select_cursor_style=args.multi_select_cursor_style,
+            multi_select_empty_ok=args.multi_select_empty_ok,
             multi_select_keys=args.multi_select_keys,
             multi_select_select_on_accept=args.multi_select_select_on_accept,
             preselected_entries=args.preselected,


### PR DESCRIPTION
Added parameter multi_select_empty_ok to be used in conjunction
with multi_select_select_on_accept=False to allow returning
from a multiselect menu with no items selected.