### PR TITLE
Add home/end key support

### DIFF
--- a/simple_term_menu.py
+++ b/simple_term_menu.py
@@ -348,17 +348,20 @@ class TerminalMenu:
 
         @active_menu_index.setter
         def active_menu_index(self, value: int) -> None:
-            self._selected_index = value
-            self._active_displayed_index = [
-                displayed_index
-                for displayed_index, menu_index in enumerate(self._displayed_index_to_menu_index)
-                if menu_index == value
-            ][0]
-            self._viewport.keep_visible(self._active_displayed_index)
+            self.active_displayed_index = self._menu_index_to_displayed_index[value]
 
         @property
         def active_displayed_index(self) -> Optional[int]:
             return self._active_displayed_index
+
+        @active_displayed_index.setter
+        def active_displayed_index(self, value: int) -> None:
+            self._active_displayed_index = value
+            self._viewport.keep_visible(self._active_displayed_index)
+
+        @property
+        def max_displayed_index(self) -> int:
+            return len(self._displayed_index_to_menu_index) - 1
 
         @property
         def displayed_selected_indices(self) -> List[int]:
@@ -507,6 +510,7 @@ class TerminalMenu:
         "cursor_visible": "cnorm",
         "delete_line": "dl1",
         "down": "kcud1",
+        "end": "kend",
         "enter_application_mode": "smkx",
         "exit_application_mode": "rmkx",
         "fg_black": "setaf 0",
@@ -517,6 +521,7 @@ class TerminalMenu:
         "fg_purple": "setaf 5",
         "fg_red": "setaf 1",
         "fg_yellow": "setaf 3",
+        "home": "khome",
         "italics": "sitm",
         "reset_attributes": "sgr0",
         "standout": "smso",
@@ -525,6 +530,8 @@ class TerminalMenu:
     }
     _name_to_control_character = {
         "backspace": "",  # Is assigned later in `self._init_backspace_control_character`
+        "ctrl-a": "\001",
+        "ctrl-e": "\005",
         "ctrl-j": "\012",
         "ctrl-k": "\013",
         "enter": "\015",
@@ -1457,6 +1464,8 @@ class TerminalMenu:
             menu_action_to_keys = {
                 "menu_up": set(("up", "ctrl-k", "k")),
                 "menu_down": set(("down", "ctrl-j", "j")),
+                "menu_start": set(("home", "ctrl-a")),
+                "menu_end": set(("end", "ctrl-e")),
                 "accept": set(self._accept_keys),
                 "multi_select": set(self._multi_select_keys),
                 "quit": set(self._quit_keys),
@@ -1485,6 +1494,10 @@ class TerminalMenu:
                     self._view.decrement_active_index()
                 elif next_key in current_menu_action_to_keys["menu_down"]:
                     self._view.increment_active_index()
+                elif next_key in current_menu_action_to_keys["menu_start"]:
+                    self._view.active_displayed_index = 0
+                elif next_key in current_menu_action_to_keys["menu_end"]:
+                    self._view.active_displayed_index = self._view.max_displayed_index
                 elif self._multi_select and next_key in current_menu_action_to_keys["multi_select"]:
                     if self._view.active_menu_index is not None:
                         self._selection.toggle(self._view.active_menu_index)


### PR DESCRIPTION
This makes the home key (or the emacs/bash-like ctrl+a) scroll to the top of the list, and the end key (or ctrl+e) scroll to the bottom.