### PR TITLE
Correct skip_empty_entries behaviour when search is active

### DIFF
--- a/simple_term_menu.py
+++ b/simple_term_menu.py
@@ -309,8 +309,8 @@ class TerminalMenu:
                     self._active_displayed_index = 0
                 self._viewport.keep_visible(self._active_displayed_index)
 
-            if self._active_displayed_index in self._skip_indices:
-                self.increment_active_index()
+                if self._displayed_index_to_menu_index[self._active_displayed_index] in self._skip_indices:
+                    self.increment_active_index()
 
         def decrement_active_index(self) -> None:
             if self._active_displayed_index is not None:
@@ -320,8 +320,8 @@ class TerminalMenu:
                     self._active_displayed_index = len(self._displayed_index_to_menu_index) - 1
                 self._viewport.keep_visible(self._active_displayed_index)
 
-            if self._active_displayed_index in self._skip_indices:
-                self.decrement_active_index()
+                if self._displayed_index_to_menu_index[self._active_displayed_index] in self._skip_indices:
+                    self.decrement_active_index()
 
         def is_visible(self, menu_index: int) -> bool:
             return menu_index in self._menu_index_to_displayed_index and (


### PR DESCRIPTION
# Repro
1. `./simple_term_menu.py hello '' world '' something else asdf jgirej boo foo --skip-empty-entries`
2. Start a search with `/` for the letter `o`
3. Navigate all the way up and down the list to see which items are usable

# Expected behaviour (PR behaviour):
No empty items are visible, so all items are selectable

# Previous behaviour:
The items which now take the place of the previously-empty menu items are not selectable