### PR TITLE
None returned if multi_select_on_accept is false even if terminal is single select

### DIFF
--- a/simple_term_menu.py
+++ b/simple_term_menu.py
@@ -1555,8 +1555,10 @@ class TerminalMenu:
                         self._selection.toggle(self._view.active_menu_index)
                 elif next_key in current_menu_action_to_keys["accept"]:
                     if self._view.active_menu_index is not None:
-                        if self._multi_select_select_on_accept or (
-                            not self._selection and self._multi_select_empty_ok is False
+                        if (
+                            self._multi_select_select_on_accept
+                            or self._multi_select is False
+                            or (not self._selection and self._multi_select_empty_ok is False)
                         ):
                             self._selection.add(self._view.active_menu_index)
                     self._chosen_accept_key = next_key


### PR DESCRIPTION
If `multi_select_on_accept=False`, `None` returns even if terminal is single select 

Code to reproduce 

```
from simple_term_menu import TerminalMenu

menu_index=TerminalMenu(
    menu_entries=['elem1', 'elem2'],
    multi_select=False,                     ### Note that multi_select is False
    multi_select_select_on_accept=False,
    multi_select_empty_ok=True,
    clear_screen=True,
).show()

assert menu_index is not None
```