### PR TITLE
Support wide characters as preview title

### DIFF
--- a/simple_term_menu.py
+++ b/simple_term_menu.py
@@ -1270,7 +1270,7 @@ class TerminalMenu:
                             BoxDrawingCharacters.upper_left
                             + (2 * BoxDrawingCharacters.horizontal + " " + self._preview_title)[: num_cols - 3]
                             + " "
-                            + (num_cols - len(self._preview_title) - 6) * BoxDrawingCharacters.horizontal
+                            + (num_cols - wcswidth(self._preview_title) - 6) * BoxDrawingCharacters.horizontal
                             + BoxDrawingCharacters.upper_right
                         )[:num_cols]
                         + "\n"


### PR DESCRIPTION
This commit fixes GitHub issue #79.

The following command test passed:
```
./simple_term_menu.py --preview-title 预览 -p echo a b c
```