### PR TITLE
Added support for search_regex_function

### DIFF
--- a/simple_term_menu.py
+++ b/simple_term_menu.py
@@ -166,10 +166,12 @@ class TerminalMenu:
             search_text: Optional[str] = None,
             case_senitive: bool = False,
             show_search_hint: bool = False,
+            search_regex_function: Optional[Callable[[str], re.Pattern]] = None,
         ):
             self._menu_entries = menu_entries
             self._case_sensitive = case_senitive
             self._show_search_hint = show_search_hint
+            self._search_regex_function = search_regex_function
             self._matches = []  # type: List[Tuple[int, Match[str]]]
             self._search_regex = None  # type: Optional[Pattern[str]]
             self._change_callback = None  # type: Optional[Callable[[], None]]
@@ -204,6 +206,8 @@ class TerminalMenu:
             self._search_text = text
             search_text = self._search_text
             self._search_regex = None
+            if search_text and self._search_regex_function:
+                self._search_regex = self._search_regex_function(search_text)
             while search_text and self._search_regex is None:
                 try:
                     self._search_regex = re.compile(search_text, flags=re.IGNORECASE if not self._case_sensitive else 0)
@@ -618,6 +622,7 @@ class TerminalMenu:
         search_case_sensitive: bool = DEFAULT_SEARCH_CASE_SENSITIVE,
         search_highlight_style: Optional[Iterable[str]] = DEFAULT_SEARCH_HIGHLIGHT_STYLE,
         search_key: Optional[str] = DEFAULT_SEARCH_KEY,
+        search_regex_function: Optional[Callable[[str], re.Pattern]] = None,
         shortcut_brackets_highlight_style: Optional[Iterable[str]] = DEFAULT_SHORTCUT_BRACKETS_HIGHLIGHT_STYLE,
         shortcut_key_highlight_style: Optional[Iterable[str]] = DEFAULT_SHORTCUT_KEY_HIGHLIGHT_STYLE,
         show_multi_select_hint: bool = DEFAULT_SHOW_MULTI_SELECT_HINT,
@@ -764,6 +769,7 @@ class TerminalMenu:
         self._search_case_sensitive = search_case_sensitive
         self._search_highlight_style = tuple(search_highlight_style) if search_highlight_style is not None else ()
         self._search_key = search_key
+        self._search_regex_function = search_regex_function
         self._shortcut_brackets_highlight_style = (
             tuple(shortcut_brackets_highlight_style) if shortcut_brackets_highlight_style is not None else ()
         )
@@ -807,6 +813,7 @@ class TerminalMenu:
             self._menu_entries,
             case_senitive=self._search_case_sensitive,
             show_search_hint=self._show_search_hint,
+            search_regex_function=self._search_regex_function,
         )
         self._selection = self.Selection(self._preselected_indices)
         self._viewport = self.Viewport(


### PR DESCRIPTION
This can be used to generate regex to limit the search query to a substring within the menu entries.
e.g.
Menu entries may be defined as
```
[
" 1 : menu A : 2024/09/18",
" 2 : menu B : 2024/09/17",
" 3 : menu C : 2024/09/19",
...
"10 : menu J : 2023/09/10"
]

```
If I want to limit the search to just the serial number, I can change the search string '2' to regex '^2', so that it does not match **2**024.

For this, I can provide an optional parameter search_regex_function defined as:

```
def my_search_regex_function(text):
    if re.match('[0-9][0-9]*$', text) and int(text) < len(menu_items):
        text = f'^ *{text}(?= : )'
    return re.compile(text, flags=re.IGNORECASE)
```

With the above function, 2 will only match menu B. 2024 will match all menu entries. The function itself can be customized for individual requirements.